### PR TITLE
Use mktemp instead of tempfile

### DIFF
--- a/tools/gen-conf.sh
+++ b/tools/gen-conf.sh
@@ -29,8 +29,8 @@
 ROOTFLDR="$( pwd )"
 SAMPLE="${ROOTFLDR}/setup/config.php.example"
 FILE="${ROOTFLDR}/setup/config.php"
-VARTMP="$( tempfile )"
-COMTMP="$( tempfile )"
+VARTMP="$( mktemp )"
+COMTMP="$( mktemp )"
 
 echo
 echo "We are going to ask you a couple of questions regarding AGUILAS configuration."


### PR DESCRIPTION
The `tempfile` utility is not available on all modern Linux systems and is an unnecessary dependency when the more standard `mktemp` will do.